### PR TITLE
Fix no-gutters typo

### DIFF
--- a/documentation/core.html
+++ b/documentation/core.html
@@ -225,7 +225,7 @@ $_golden-ratio:     1.618
 </code></pre><h3>Column offsets</h3><p>There are cases where you need to move a column to the right side without creating an empty column next to it. For this, you can use column offsets, which are pretty simple to use.</p><p>You just have to add a number from <code>1</code> to <code>11</code> prefixed with the plus symbol (<code>+</code>) in the <code>column</code> element.</p><pre class="language-markup"><code>&lt;main grid>
 &lt;article column='8 +2'>…&lt;/article>
 &lt;/main>
-</code></pre><p>In that example, we have created a column with a width of 8/12 and with an offset of 2/12.</p><h3>Columns without gutters</h3><p>You can create columns without gutters by adding a <code>no-gutter</code> value in the <code>grid</code> attribute, like this:</p><pre class="language-markup"><code>&lt;main grid="no-gutter">
+</code></pre><p>In that example, we have created a column with a width of 8/12 and with an offset of 2/12.</p><h3>Columns without gutters</h3><p>You can create columns without gutters by adding a <code>no-gutters</code> value in the <code>grid</code> attribute, like this:</p><pre class="language-markup"><code>&lt;main grid="no-gutters">
   &lt;article column>…&lt;/article>
   &lt;article column>…&lt;/article>
   &lt;article column>…&lt;/article>

--- a/src/documentation/core.pug
+++ b/src/documentation/core.pug
@@ -414,10 +414,10 @@ block content
 
   h3 Columns without gutters
 
-  p You can create columns without gutters by adding a #[code no-gutter] value in the #[code grid] attribute, like this:
+  p You can create columns without gutters by adding a #[code no-gutters] value in the #[code grid] attribute, like this:
 
   pre.language-markup: code.
-    &lt;main grid="no-gutter">
+    &lt;main grid="no-gutters">
       &lt;article column>…&lt;/article>
       &lt;article column>…&lt;/article>
       &lt;article column>…&lt;/article>


### PR DESCRIPTION
the css declaration is .no-gutters (plural), but documentation says .no-gutter (singular)